### PR TITLE
Show all pets

### DIFF
--- a/public/assets/js/GPreq/getLostFoundPets.js
+++ b/public/assets/js/GPreq/getLostFoundPets.js
@@ -1,4 +1,23 @@
+function getRequest=$.get("/api/pets",
+    function (data) {
 
+      for (var i = 0; i < data.length; i++) {
+        if (data[i].found_location) {
+          let mapPoint = data[i].found_location.split(',')
+          let mapPointParsed = [parseFloat(mapPoint[0]), parseFloat(mapPoint[1])]
+          if (data[i].type === "Dog") {
+            marker = new L.marker((mapPointParsed), { icon: doggyIcon })
+              .bindPopup("Animal_ID " + String(data[i].animal_ID))
+              markers.addLayer(marker);
+          }
+          else if (data[i].type === "Cat") {
+            marker = new L.marker((mapPointParsed), { icon: kittayIcon })
+              .bindPopup("Animal_ID " + String(data[i].animal_ID))
+              markers.addLayer(marker);
+          }
+        }
+      }
+    });
 $(document).ready(function () {
   $(".reset").hide();
   var kittayIcon = L.icon({
@@ -22,7 +41,7 @@ $(document).ready(function () {
   });
   key = "AIzaSyD70EcFlRlgIbc1ARNvns5CszqjaUyQzVI";
   // initialize the map
-  var mymap = L.map('map').setView([30.2672, -97.7431], 13);
+  var mymap = L.map('map').setView([30.2672, -97.7431], 12);
 
   // load a tile layer
   L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoiamN0b2JleSIsImEiOiJjam9kNGs3MzMwczI2M3BwYjVtaXRpZ2l1In0.sxKzZ76nyy_PN8ETEnoKKA', {
@@ -32,30 +51,11 @@ $(document).ready(function () {
     accessToken: 'pk.eyJ1IjoiamN0b2JleSIsImEiOiJjam9kNGs3MzMwczI2M3BwYjVtaXRpZ2l1In0.sxKzZ76nyy_PN8ETEnoKKA'
   }).addTo(mymap);
   var markers = new L.FeatureGroup();
-  $.get("/api/pets",
-    function (data) {
-
-      for (var i = 0; i < data.length; i++) {
-        if (data[i].found_location) {
-          let mapPoint = data[i].found_location.split(',')
-          let mapPointParsed = [parseFloat(mapPoint[0]), parseFloat(mapPoint[1])]
-          if (data[i].type === "Dog") {
-            marker = new L.marker((mapPointParsed), { icon: doggyIcon })
-              .bindPopup("Animal_ID " + String(data[i].animal_ID))
-              markers.addLayer(marker);
-          }
-          else if (data[i].type === "Cat") {
-            marker = new L.marker((mapPointParsed), { icon: kittayIcon })
-              .bindPopup("Animal_ID " + String(data[i].animal_ID))
-              markers.addLayer(marker);
-          }
-        }
-      }
-    });
     mymap.addLayer(markers);
     function clearAllMarkers(){
       markers.clearLayers();
   }
+  getRequest();
 
   var table = new Tabulator("#tabulator-table", {
     height: "311px",

--- a/public/assets/js/GPreq/getLostFoundPets.js
+++ b/public/assets/js/GPreq/getLostFoundPets.js
@@ -1,6 +1,6 @@
 
 $(document).ready(function () {
-
+  $(".reset").hide();
   var kittayIcon = L.icon({
     iconUrl: './assets/img/kittay.png', //"public/assets/img/kittay.png",
 
@@ -90,13 +90,14 @@ $(document).ready(function () {
           .bindPopup("Animal_ID " + String(rowClicked.animal_ID))
           markers.addLayer(marker);
       }
-   
+      $(".reset").show();
   }
 })
   table.setData("/api/pets");
 
   function onMapClick(e) {
     marker.openPopup();
+    
   }
   mymap.on('click', onMapClick);
 })

--- a/public/assets/js/GPreq/getLostFoundPets.js
+++ b/public/assets/js/GPreq/getLostFoundPets.js
@@ -1,23 +1,4 @@
-function getRequest=$.get("/api/pets",
-    function (data) {
 
-      for (var i = 0; i < data.length; i++) {
-        if (data[i].found_location) {
-          let mapPoint = data[i].found_location.split(',')
-          let mapPointParsed = [parseFloat(mapPoint[0]), parseFloat(mapPoint[1])]
-          if (data[i].type === "Dog") {
-            marker = new L.marker((mapPointParsed), { icon: doggyIcon })
-              .bindPopup("Animal_ID " + String(data[i].animal_ID))
-              markers.addLayer(marker);
-          }
-          else if (data[i].type === "Cat") {
-            marker = new L.marker((mapPointParsed), { icon: kittayIcon })
-              .bindPopup("Animal_ID " + String(data[i].animal_ID))
-              markers.addLayer(marker);
-          }
-        }
-      }
-    });
 $(document).ready(function () {
   $(".reset").hide();
   var kittayIcon = L.icon({
@@ -51,11 +32,30 @@ $(document).ready(function () {
     accessToken: 'pk.eyJ1IjoiamN0b2JleSIsImEiOiJjam9kNGs3MzMwczI2M3BwYjVtaXRpZ2l1In0.sxKzZ76nyy_PN8ETEnoKKA'
   }).addTo(mymap);
   var markers = new L.FeatureGroup();
+  $.get("/api/pets",
+    function (data) {
+
+      for (var i = 0; i < data.length; i++) {
+        if (data[i].found_location) {
+          let mapPoint = data[i].found_location.split(',')
+          let mapPointParsed = [parseFloat(mapPoint[0]), parseFloat(mapPoint[1])]
+          if (data[i].type === "Dog") {
+            marker = new L.marker((mapPointParsed), { icon: doggyIcon })
+              .bindPopup("Animal_ID " + String(data[i].animal_ID))
+              markers.addLayer(marker);
+          }
+          else if (data[i].type === "Cat") {
+            marker = new L.marker((mapPointParsed), { icon: kittayIcon })
+              .bindPopup("Animal_ID " + String(data[i].animal_ID))
+              markers.addLayer(marker);
+          }
+        }
+      }
+    });
     mymap.addLayer(markers);
     function clearAllMarkers(){
       markers.clearLayers();
   }
-  getRequest();
 
   var table = new Tabulator("#tabulator-table", {
     height: "311px",
@@ -99,7 +99,30 @@ $(document).ready(function () {
     marker.openPopup();
     
   }
+  $(".reset").on("click", function (event) {$.get("/api/pets",
+  function (data) {
+
+    for (var i = 0; i < data.length; i++) {
+      if (data[i].found_location) {
+        let mapPoint = data[i].found_location.split(',')
+        let mapPointParsed = [parseFloat(mapPoint[0]), parseFloat(mapPoint[1])]
+        if (data[i].type === "Dog") {
+          marker = new L.marker((mapPointParsed), { icon: doggyIcon })
+            .bindPopup("Animal_ID " + String(data[i].animal_ID))
+            markers.addLayer(marker);
+        }
+        else if (data[i].type === "Cat") {
+          marker = new L.marker((mapPointParsed), { icon: kittayIcon })
+            .bindPopup("Animal_ID " + String(data[i].animal_ID))
+            markers.addLayer(marker);
+        }
+      }
+    }
+  });
+
+  })
   mymap.on('click', onMapClick);
+  
 })
 
 

--- a/public/assets/js/GPreq/getLostFoundPets.js
+++ b/public/assets/js/GPreq/getLostFoundPets.js
@@ -1,4 +1,25 @@
+function getMapResults(){
+  $.get("/api/pets",
+    function (data) {
 
+      for (var i = 0; i < data.length; i++) {
+        if (data[i].found_location) {
+          let mapPoint = data[i].found_location.split(',')
+          let mapPointParsed = [parseFloat(mapPoint[0]), parseFloat(mapPoint[1])]
+          if (data[i].type === "Dog") {
+            marker = new L.marker((mapPointParsed), { icon: doggyIcon })
+              .bindPopup("Animal_ID " + String(data[i].animal_ID))
+              markers.addLayer(marker);
+          }
+          else if (data[i].type === "Cat") {
+            marker = new L.marker((mapPointParsed), { icon: kittayIcon })
+              .bindPopup("Animal_ID " + String(data[i].animal_ID))
+              markers.addLayer(marker);
+          }
+        }
+      }
+    });
+}
 $(document).ready(function () {
   $(".reset").hide();
   var kittayIcon = L.icon({
@@ -32,26 +53,7 @@ $(document).ready(function () {
     accessToken: 'pk.eyJ1IjoiamN0b2JleSIsImEiOiJjam9kNGs3MzMwczI2M3BwYjVtaXRpZ2l1In0.sxKzZ76nyy_PN8ETEnoKKA'
   }).addTo(mymap);
   var markers = new L.FeatureGroup();
-  $.get("/api/pets",
-    function (data) {
-
-      for (var i = 0; i < data.length; i++) {
-        if (data[i].found_location) {
-          let mapPoint = data[i].found_location.split(',')
-          let mapPointParsed = [parseFloat(mapPoint[0]), parseFloat(mapPoint[1])]
-          if (data[i].type === "Dog") {
-            marker = new L.marker((mapPointParsed), { icon: doggyIcon })
-              .bindPopup("Animal_ID " + String(data[i].animal_ID))
-              markers.addLayer(marker);
-          }
-          else if (data[i].type === "Cat") {
-            marker = new L.marker((mapPointParsed), { icon: kittayIcon })
-              .bindPopup("Animal_ID " + String(data[i].animal_ID))
-              markers.addLayer(marker);
-          }
-        }
-      }
-    });
+  getMapResults();
     mymap.addLayer(markers);
     function clearAllMarkers(){
       markers.clearLayers();
@@ -99,27 +101,8 @@ $(document).ready(function () {
     marker.openPopup();
     
   }
-  $(".reset").on("click", function (event) {$.get("/api/pets",
-  function (data) {
-
-    for (var i = 0; i < data.length; i++) {
-      if (data[i].found_location) {
-        let mapPoint = data[i].found_location.split(',')
-        let mapPointParsed = [parseFloat(mapPoint[0]), parseFloat(mapPoint[1])]
-        if (data[i].type === "Dog") {
-          marker = new L.marker((mapPointParsed), { icon: doggyIcon })
-            .bindPopup("Animal_ID " + String(data[i].animal_ID))
-            markers.addLayer(marker);
-        }
-        else if (data[i].type === "Cat") {
-          marker = new L.marker((mapPointParsed), { icon: kittayIcon })
-            .bindPopup("Animal_ID " + String(data[i].animal_ID))
-            markers.addLayer(marker);
-        }
-      }
-    }
-  });
-
+  $(".reset").on("click", function (event) {
+    getMapResults()
   })
   mymap.on('click', onMapClick);
   

--- a/public/assets/js/GPreq/getLostFoundPets.js
+++ b/public/assets/js/GPreq/getLostFoundPets.js
@@ -1,26 +1,5 @@
-function getMapResults(){
-  $.get("/api/pets",
-    function (data) {
-
-      for (var i = 0; i < data.length; i++) {
-        if (data[i].found_location) {
-          let mapPoint = data[i].found_location.split(',')
-          let mapPointParsed = [parseFloat(mapPoint[0]), parseFloat(mapPoint[1])]
-          if (data[i].type === "Dog") {
-            marker = new L.marker((mapPointParsed), { icon: doggyIcon })
-              .bindPopup("Animal_ID " + String(data[i].animal_ID))
-              markers.addLayer(marker);
-          }
-          else if (data[i].type === "Cat") {
-            marker = new L.marker((mapPointParsed), { icon: kittayIcon })
-              .bindPopup("Animal_ID " + String(data[i].animal_ID))
-              markers.addLayer(marker);
-          }
-        }
-      }
-    });
-}
 $(document).ready(function () {
+
   $(".reset").hide();
   var kittayIcon = L.icon({
     iconUrl: './assets/img/kittay.png', //"public/assets/img/kittay.png",
@@ -44,7 +23,28 @@ $(document).ready(function () {
   key = "AIzaSyD70EcFlRlgIbc1ARNvns5CszqjaUyQzVI";
   // initialize the map
   var mymap = L.map('map').setView([30.2672, -97.7431], 12);
-
+  function getMapResults(){
+    $.get("/api/pets",
+      function (data) {
+  
+        for (var i = 0; i < data.length; i++) {
+          if (data[i].found_location) {
+            let mapPoint = data[i].found_location.split(',')
+            let mapPointParsed = [parseFloat(mapPoint[0]), parseFloat(mapPoint[1])]
+            if (data[i].type === "Dog") {
+              marker = new L.marker((mapPointParsed), { icon: doggyIcon })
+                .bindPopup("Animal_ID " + String(data[i].animal_ID))
+                markers.addLayer(marker);
+            }
+            else if (data[i].type === "Cat") {
+              marker = new L.marker((mapPointParsed), { icon: kittayIcon })
+                .bindPopup("Animal_ID " + String(data[i].animal_ID))
+                markers.addLayer(marker);
+            }
+          }
+        }
+      });
+  }
   // load a tile layer
   L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoiamN0b2JleSIsImEiOiJjam9kNGs3MzMwczI2M3BwYjVtaXRpZ2l1In0.sxKzZ76nyy_PN8ETEnoKKA', {
     attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',

--- a/public/assets/js/GPreq/postFoundPet.js
+++ b/public/assets/js/GPreq/postFoundPet.js
@@ -35,6 +35,13 @@ $(document).ready(function () {
       var clickedPoint=""
       var clickedPointString=""
       var clickedPointResponse=""
+      var clickedIcon=""
+      $(".dog-icon").on("click", function (event) {
+        clickedIcon="Dog"
+      })
+      $(".cat-icon").on("click", function (event) {
+        clickedIcon="Cat"
+      })
       function onMapClick(e) {
         
         if(Address.length>0){
@@ -50,9 +57,9 @@ $(document).ready(function () {
           let geocodeRequest = `https://maps.googleapis.com/maps/api/geocode/json?latlng=${clickedPointString}&key=${key}`;
           $.get(geocodeRequest).then(response => {
             clickedPointResponse = response.results[0].formatted_address;
-             if($(".dog-icon.active")){
+             if(clickedIcon==="Dog"){
              clickedPointMarker = L.marker(clickedPoint, {icon:doggyIcon})}
-             else if($(".cat-icon.active")){
+             else if(clickedIcon==="Cat"){
             clickedPointMarker = L.marker(clickedPoint, {icon:kittayIcon})}
              
              clickedPointMarker.addTo(mymap).bindPopup(`You clicked on: <br> ${clickedPointResponse}`).openPopup();
@@ -64,6 +71,7 @@ $(document).ready(function () {
         searchAddress()
       }
       mymap.on('click', onMapClick);
+      
      
     $(".submit").on("click", function (event) {
       event.preventDefault();

--- a/public/landing-page.html
+++ b/public/landing-page.html
@@ -171,7 +171,8 @@
   <script src="./assets/js/material-kit.js?v=2.0.4" type="text/javascript"></script>
    
   <script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"></script>
-  <script src="./assets/js/GPreq/postLostFoundPet.js"></script>
+  <script src="./assets/js/GPreq/postFoundPet.js"></script>
+  <script src="./assets/js/GPreq/postLostPet.js"></script>
   <script src="./assets/js/script.js"></script>
 </body>
 

--- a/public/map-results.html
+++ b/public/map-results.html
@@ -96,7 +96,7 @@
             <div id="map"></div>
             <div id="first"></div>
           </div>
-
+          <a class="waves-effect waves-light btn reset">Reset Map</a>
           <br>
 
           <div class="profile-tabs lost-found">


### PR DESCRIPTION
Fixes #91 I added a materialize button that unhides when a row is clicked in the tabulator table, the button resets the map with all of the pets from the DB.

Not ideal, I would like it to also reset the tabulator table (that should be easy) but that's a nice to have :)

I also made the initial zoom a little bit lower, so that the whole map of austin shows (it works a little better that way once a tabulator row is clicked).

I also fixed the icon grabbing issue on the found form. Will push more comprehensive fix tonight that fixes icon grabbing on lost pets and database page.